### PR TITLE
Update to bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_window_title_diagnostics"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Logs Bevy diagnostics into the primary window title"
 repository = "https://github.com/Stazis555/bevy_window_title_diagnostics"
@@ -13,4 +13,4 @@ categories = ["game-engines"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.14"
+bevy = "0.15"

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Made for little bit more convenient usage of the FrameTimeDiagnosticsPlugin
 
 Add to your `Cargo.toml`
 
-For bevy 0.13:
+For bevy 0.15:
 
 ```rust
-bevy_window_title_diagnostics = 0.13
+bevy_window_title_diagnostics = 0.15
 
 ```
 
@@ -27,40 +27,43 @@ use bevy_window_title_diagnostics::WindowTitleLoggerDiagnosticsPlugin;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_plugin(FrameTimeDiagnosticsPlugin)
-        // Insert same way as usual LogDiagnosticsPlugin
-        .add_plugin(WindowTitleLoggerDiagnosticsPlugin {
-            // It is possible to filter Diagnostics same way as default LogDiagnosticsPlugin
-            // filter: Some(vec![FrameTimeDiagnosticsPlugin::FPS]),
-            ..Default::default()
-        })
-        // Works with any diagnostics
-        // .add_plugin(bevy::diagnostic::EntityCountDiagnosticsPlugin::default())
+        .add_systems(Startup, setup)
+        .add_plugins((
+            FrameTimeDiagnosticsPlugin,
+            // Insert same way as usual LogDiagnosticsPlugin
+            WindowTitleLoggerDiagnosticsPlugin {
+                // It is possible to filter Diagnostics same way as default LogDiagnosticsPlugin
+                // filter: Some(vec![FrameTimeDiagnosticsPlugin::FPS]),
+                ..Default::default()
+            },
+            // Works with any diagnostics
+            // bevy::diagnostic::EntityCountDiagnosticsPlugin::default(),
+        ))
         .run();
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::new_with_far(10.0));
-    commands.spawn(SpriteBundle {
-        sprite: Sprite {
-            color: Color::CYAN,
-            custom_size: Some(Vec2::new(50.0, 50.0)),
-            ..default()
-        },
+    commands.spawn(Camera2d::default());
+    commands.spawn(Sprite {
+        color: Color::srgb(0.0, 0.0, 1.0),
+        custom_size: Some(Vec2::new(50.0, 50.0)),
         ..default()
     });
 }
+
 ```
 
 # Bevy compatibility table
 
 | Bevy version | bevy_window_title_diagnostics version |
-| ------------ | ------------------------------------- |
-| 0.8          | 0.2                                   |
-| 0.9          | 0.3                                   |
-| 0.10         | 0.4                                   |
+| ------------ | ------------------------------------- | --- | ---- |
+| 0.15         | 0.15                                  |
+| 0.14         | 0.14                                  |
+| 0.13         | 0.13                                  |
+| 0.12         | 0.6                                   |     | 0.12 |
 | 0.11         | 0.5                                   |
-| 0.12         | 0.6 || 0.12                           |
+| 0.10         | 0.4                                   |
+| 0.9          | 0.3                                   |
+| 0.8          | 0.2                                   |
 
 Starting from bevy 0.12 library will have the same semantic version as bevy

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -21,13 +21,10 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::new_with_far(10.0));
-    commands.spawn(SpriteBundle {
-        sprite: Sprite {
-            color: Color::srgb(0.0, 0.0, 1.0),
-            custom_size: Some(Vec2::new(50.0, 50.0)),
-            ..default()
-        },
+    commands.spawn(Camera2d::default());
+    commands.spawn(Sprite {
+        color: Color::srgb(0.0, 0.0, 1.0),
+        custom_size: Some(Vec2::new(50.0, 50.0)),
         ..default()
     });
 }


### PR DESCRIPTION
Updated Cargo.toml, example & README. The main plugin didn't need changes.